### PR TITLE
allow pass to git-update-server-info when fetching error

### DIFF
--- a/mirror.go
+++ b/mirror.go
@@ -17,7 +17,7 @@ func mirror(cfg config, r repo) (string, error) {
 		out, err := cmd.CombinedOutput()
 		outStr = string(out)
 		if err != nil {
-			return outStr, fmt.Errorf("failed to update remote in %s, %s", repoPath, err)
+			fmt.Fprintf(os.Stderr, "failed to update remote in %s, %s", repoPath, err)
 		}
 	} else if os.IsNotExist(err) {
 		// Clone
@@ -30,7 +30,7 @@ func mirror(cfg config, r repo) (string, error) {
 		out, err := cmd.CombinedOutput()
 		outStr = string(out)
 		if err != nil {
-			return outStr, fmt.Errorf("failed to clone %s, %s", r.Origin, err)
+			fmt.Fprintf(os.Stderr, "failed to clone %s, %s", r.Origin, err)
 		}
 		return string(out), err
 	} else {


### PR DESCRIPTION
sometimes `git fetch` (git remote update) returns error for reason like `error: cannot lock ref 'refs/heads/.....>': 'refs/heads/.....' exists; cannot create 'refs/heads/...' ` for branches contain slashes. But the copy is almost correct and synced. So we need to `git update-server-info` in most cases to announce branches and heads for http/https transport. https://stackoverflow.com/a/2085582