### PR TITLE
Add --prune option when updating

### DIFF
--- a/mirror.go
+++ b/mirror.go
@@ -12,7 +12,7 @@ func mirror(cfg config, r repo) (string, error) {
 	outStr := ""
 	if _, err := os.Stat(repoPath); err == nil {
 		// Directory exists, update.
-		cmd := exec.Command("git", "remote", "update")
+		cmd := exec.Command("git", "remote", "update", "--prune")
 		cmd.Dir = repoPath
 		out, err := cmd.CombinedOutput()
 		outStr = string(out)


### PR DESCRIPTION
To stop growing of the mirror repository and to delete rubbish branches

Already tested '--prune' option itself on the mirror and container. Now let's write it down into the script. Then I update the host.